### PR TITLE
Updated guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ to which you want to deploy your Hello World application.
   service. 
   > Although all the `kubectl` (as well as the `helm` and `run.sh`) commands in the rest of this tutorial also are using the `default` namespace, you can in those cases use the corresponding command line options for specifying another namespace, where you do have access rights.
 
+  - You also need a CAS on your Kubernetes cluster. Which you can install with the [Kubectl provision plugin](https://sconedocs.github.io/5_kubectl/) and exectuing:
+
+   ```bash
+   kubectl provision cas <name> -v
+   ```
+
 
 ### Step 1: Write the Services of Your Application
 
@@ -198,14 +204,9 @@ and a *mesh manifest file* (a.k.a. *meshfile*) for your application.
 In this `Hello World` example, this amounts to just two files which
 have already been created for you. You just need to:
 
-1. Change the `build.to` field in the provided `service.yaml` file to point to
-the repository and image name, to which you want to upload the generated
-container image containing the service. To make it easier to follow
-the steps below, we recommend using the image tag `1`.
-2. Change the `services.image` field in the `mesh.yaml` file to point to the same
-image as in the `service.yaml` file.
-3. Change the `policy.namespace` field in the `mesh.yaml` file to a unique
-[SCONE CAS namespace](https://sconedocs.github.io/namespace/) of your choice.
+ - Specify an image repository where you can store the generated, confidential image: pass this along to the run.sh script with argument --image-repo <REPO>.
+
+ - Optionally, change the Kubernetes namespace by passing argument --namespace <kubernetes-namespace> to the run script.
 
 > **NOTE:** A *service manifest file* is a `yaml` file, in which you describe the
 service by specifying different properties. These include but are not limited to:
@@ -232,7 +233,7 @@ service by specifying different properties. These include but are not limited to
 
 ### Step 3: Build and Deploy Your Application
 
-Once you have created your manifest files, you only need to run:
+Execute the following command:
 
 ```bash
 ./run.sh
@@ -240,6 +241,7 @@ Once you have created your manifest files, you only need to run:
 to build and run your confidential application on Kubernetes.
 
 > **NOTE:** Under the hood `run.sh` executes the following three commands:
+>
 > 1. Build the OCI container images containing your services and push it to your 
 > repository by executing the following command (once per service):
 >
@@ -255,6 +257,7 @@ to build and run your confidential application on Kubernetes.
 >   in the current directory on your local machine.
 >     - generate the security policies and global variables and upload them to the 
 >   SCONE CAS instance specified in the `mesh.yaml` file.
+>
 > 3. Deploy the application using the generated helm chart:
 >   ```bash
 >   helm install pythonapp target/helm
@@ -578,12 +581,12 @@ To verify the consistency protection of the **program**, we would have to create
    sudo rm -rf release.sh target/
    ```
 
-3. Build and deploy version 2:
-   1. Create a new version, i.e., version 2, of the program by changing
+3. Build and deploy version 2 by:
+   1. Creating a new version, i.e., version 2, of the program by changing
    a log message printed in the loop in `print_env.py` in the repository.
-   2. Change the image tag in `service.yaml.template` under `build.to` to `2`.
-   3. Change the image tag in `mesh.yaml.template` under `services.image` to `2`.
-   4. Build and deploy the new version, version 2, of the application:
+   2. Changing the image tag in `service.yaml.template` under `build.to` to `2`.
+   3. Changing the image tag in `mesh.yaml.template` under `services.image` to `2`.
+   4. Building and deploying the new version, version 2, of the application by running the following script:
 
       ```bash
       ./run.sh

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ to which you want to deploy your Hello World application.
   curl -fsSL https://raw.githubusercontent.com/scontain/SH/master/operator_controller | bash -s - --set-version 5.8.0-rc.1 --reconcile --update --secret-operator  --plugin --verbose  --username $REGISTRY_USERNAME --access-token $REGISTRY_ACCESS_TOKEN --email $REGISTRY_EMAIL
   ```
 
-  You can check whether the two DaemonSets are installed by executing:
+  You can check whether the two custom resources are installed by executing:
     
   ```bash
   kubectl get las 
   kubectl get sgxplugin
   ```
 
-  > **NOTE:** If you are not authorized to use `default` Kubernetes namespace, you will have to ask somebody with access to install the [SCONE SGX Plugin](https://sconedocs.github.io/helm_sgxdevplugin/) 
+  > **NOTE:** If you are not authorized to install the services, you will have to ask somebody with access to install the [SCONE SGX Plugin](https://sconedocs.github.io/helm_sgxdevplugin/) 
   service and the [SCONE LAS](https://sconedocs.github.io/helm_las/)
   service. 
   > Although all the `kubectl` (as well as the `helm` and `run.sh`) commands in the rest of this tutorial also are using the `default` namespace, you can in those cases use the corresponding command line options for specifying another namespace, where you do have access rights.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ to which you want to deploy your Hello World application.
   service. 
   > Although all the `kubectl` (as well as the `helm` and `run.sh`) commands in the rest of this tutorial also are using the `default` namespace, you can in those cases use the corresponding command line options for specifying another namespace, where you do have access rights.
 
-  - You also need a CAS on your Kubernetes cluster. Which you can install with the [Kubectl provision plugin](https://sconedocs.github.io/5_kubectl/) and exectuing:
+  - You will also need a CAS on your Kubernetes cluster. In case of our workshops, please skip this step.
+  
+  You can install a CAS on your cluster with the [Kubectl provision plugin](https://sconedocs.github.io/5_kubectl/) and running:
 
    ```bash
    kubectl provision cas <name> -v

--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ to which you want to deploy your Hello World application.
   service. 
   > Although all the `kubectl` (as well as the `helm` and `run.sh`) commands in the rest of this tutorial also are using the `default` namespace, you can in those cases use the corresponding command line options for specifying another namespace, where you do have access rights.
 
-  - You will also need access to a CAS running in your kubernetes cluster for the course of this tutorial. If you do not yet have access to one, you can create a CAS using our kubectl plugin kubectl provision:
+- You will also need access to a CAS running in your kubernetes cluster for the course of this
+  tutorial. If you do not yet have access to one, you can create a CAS using our kubectl plugin kubectl provision:
 
-   ```bash
-   kubectl provision cas <cas name> -n <cas namespace> --verbose 
-   ```
+  ```bash
+  kubectl provision cas <cas name> -n <cas namespace> --verbose 
+  ```
 
 
 ### Step 1: Write the Services of Your Application
@@ -204,7 +205,7 @@ and a *mesh manifest file* (a.k.a. *meshfile*) for your application.
 In this `Hello World` example, this amounts to just two files which
 have already been created for you. You just need to:
 
- - Specify an image repository where you can store the generated, confidential image: pass this along to the run.sh script with argument --image-repo <REPO>, or by setting the environment variable APP_IMAGE_REPO..
+ - Specify an image repository where you can store the generated, confidential image: pass this along to the `run.sh` script with argument `--image-rep <REPO>`, or by setting the environment variable `APP_IMAGE_REPO`..
 
  - Optionally, change the Kubernetes namespace by passing argument --namespace <kubernetes-namespace> to the run script. This will be the namespace where the application will be deployed. --cas and --cas-namespace can be used to specify the CAS to use for the application and the namespace for the CAS.
 
@@ -271,6 +272,8 @@ to build and run your confidential application on Kubernetes.
 > If the latter fails, check the
 > [troubleshooting section](#not-allowed-to-pull-from-scone-registry)
 > on what to do.
+
+> **NOTE:** If you want to see more options, execute `./run.sh --help`.
 
 **Congratulations! You made it!** You now have the confidential `Hello World` application running on your Kubernetes cluster.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ to which you want to deploy your Hello World application.
 
 - On your Kubernetes cluster, the [SCONE SGX Plugin](https://sconedocs.github.io/helm_sgxdevplugin/) 
   service and the [SCONE LAS](https://sconedocs.github.io/helm_las/)
-  service need to be installed in the default Kubernetes namespace. Note that if your Kubernetes config does not give you access to the default namespace, this will fail. In case of our workshops, please skip this step.
+  service need to be installed . 
   
   You can install them by running (see [Installation Instructions](https://sconedocs.github.io/2_operator_installation/)):
    
@@ -130,12 +130,10 @@ to which you want to deploy your Hello World application.
   service. 
   > Although all the `kubectl` (as well as the `helm` and `run.sh`) commands in the rest of this tutorial also are using the `default` namespace, you can in those cases use the corresponding command line options for specifying another namespace, where you do have access rights.
 
-  - You will also need a CAS on your Kubernetes cluster. In case of our workshops, please skip this step.
-  
-  You can install a CAS on your cluster with the [Kubectl provision plugin](https://sconedocs.github.io/5_kubectl/) and running:
+  - You will also need access to a CAS running in your kubernetes cluster for the course of this tutorial. If you do not yet have access to one, you can create a CAS using our kubectl plugin kubectl provision:
 
    ```bash
-   kubectl provision cas <name> -v
+   kubectl provision cas <cas name> -n <cas namespace> --verbose 
    ```
 
 
@@ -206,9 +204,9 @@ and a *mesh manifest file* (a.k.a. *meshfile*) for your application.
 In this `Hello World` example, this amounts to just two files which
 have already been created for you. You just need to:
 
- - Specify an image repository where you can store the generated, confidential image: pass this along to the run.sh script with argument --image-repo <REPO>.
+ - Specify an image repository where you can store the generated, confidential image: pass this along to the run.sh script with argument --image-repo <REPO>, or by setting the environment variable APP_IMAGE_REPO..
 
- - Optionally, change the Kubernetes namespace by passing argument --namespace <kubernetes-namespace> to the run script.
+ - Optionally, change the Kubernetes namespace by passing argument --namespace <kubernetes-namespace> to the run script. This will be the namespace where the application will be deployed. --cas and --cas-namespace can be used to specify the CAS to use for the application and the namespace for the CAS.
 
 > **NOTE:** A *service manifest file* is a `yaml` file, in which you describe the
 service by specifying different properties. These include but are not limited to:

--- a/check_prerequisites.sh
+++ b/check_prerequisites.sh
@@ -156,7 +156,7 @@ echo -e "${BLUE}Checking if the CAS '$CAS' in namespace '$CAS_NAMESPACE' is inst
 if ! (kubectl get cas "$CAS" -n "$CAS_NAMESPACE" )
 then
     echo -e "${RED}It seems that CAS '$CAS' in namespace '$CAS_NAMESPACE' is not yet running!${NC}"
-    echo -e "- ${ORANGE}- You can install a cas as follows: kubectl provision cas $CAS $CAS_NAMESPACE -v${NC}"
+    echo -e "- ${ORANGE}- You can install a cas as f    ollows: kubectl provision cas $CAS -n $CAS_NAMESPACE -v${NC}"
     error_exit
 fi
 
@@ -166,7 +166,7 @@ if ! [[ "$STATUS" == "\"HEALTHY\"" ]]
 then
     echo -e "${RED}It seems that CAS '$CAS' in namespace '$CAS_NAMESPACE' is not healthy: status is $STATUS${NC}"
     echo -e "- ${ORANGE}- The CAS might be in a working state anyhow. We are exiting this code anyhow.${NC}"
-    echo -e "- ${ORANGE}- You can install a cas as follows: kubectl provision cas $CAS $CAS_NAMESPACE -v${NC}"
+    echo -e "- ${ORANGE}- You can install a cas as follows: kubectl provision cas $CAS -n $CAS_NAMESPACE -v${NC}"
     error_exit
 fi
 

--- a/check_prerequisites.sh
+++ b/check_prerequisites.sh
@@ -7,6 +7,7 @@ export CAS_VERSION=${CAS_VERSION:-$VERSION}
 export RED='\e[31m'
 export BLUE='\e[34m'
 export ORANGE='\e[33m'
+export GREEN="\e[32m"
 export NC='\e[0m' # No Color
 
 export SCONECTL_REPO=${SCONECTL_REPO:="registry.scontain.com/sconectl"}
@@ -155,6 +156,7 @@ echo -e "${BLUE}Checking if the CAS '$CAS' in namespace '$CAS_NAMESPACE' is inst
 if ! (kubectl get cas "$CAS" -n "$CAS_NAMESPACE" )
 then
     echo -e "${RED}It seems that CAS '$CAS' in namespace '$CAS_NAMESPACE' is not yet running!${NC}"
+    echo -e "- ${ORANGE}- You can install a cas as follows: kubectl provision cas $CAS $CAS_NAMESPACE -v${NC}"
     error_exit
 fi
 
@@ -177,4 +179,4 @@ then
     error_exit
 fi
 
-
+echo -e "${GREEN}All prerequisites met${NC}"

--- a/run.sh
+++ b/run.sh
@@ -192,6 +192,7 @@ fi
 ./check_prerequisites.sh
 
 echo -e "${BLUE}Checking that we have access to the base container image${NC}"
+echo -e "${BLUE}If you don't have the image, it will be pulled. This will take some time.${NC}"
 
 docker inspect $SCONECTL_REPO/sconecli:${VERSION} > /dev/null 2> /dev/null || docker pull $SCONECTL_REPO/sconecli:${VERSION} > /dev/null 2> /dev/null || { 
     echo -e "${RED}You must get access to image `${SCONECTL_REPO}/sconecli:${VERSION}`.${NC}" 

--- a/run.sh
+++ b/run.sh
@@ -88,6 +88,9 @@ usage ()
   echo "To use image from a different repository (e.g., a local cache), set "
   echo "   export SCONECTL_REPO (=\"$SCONECTL_REPO\")"
   echo "to the repo you want to use instead. Currently selected repo is $SCONECTL_REPO."
+  echo "By default this uses the latest release of the CAS: By setting environment variable"
+  echo "   export CAS_VESION=\"<CAS_VERSION>\""
+  echo "you can select a different version. Currently selected version is $CAS_VERSION."
   return
 }
 

--- a/run.sh
+++ b/run.sh
@@ -192,7 +192,7 @@ fi
 ./check_prerequisites.sh
 
 echo -e "${BLUE}Checking that we have access to the base container image${NC}"
-echo -e "${BLUE}If you don't have the image, it will be pulled. This will take some time.${NC}"
+echo -e "${BLUE}If the image is not yet available locally, it will be pulled. This might take some time.${NC}"
 
 docker inspect $SCONECTL_REPO/sconecli:${VERSION} > /dev/null 2> /dev/null || docker pull $SCONECTL_REPO/sconecli:${VERSION} > /dev/null 2> /dev/null || { 
     echo -e "${RED}You must get access to image `${SCONECTL_REPO}/sconecli:${VERSION}`.${NC}" 


### PR DESCRIPTION
Updated the README.md file, the check_prerequisites.sh and the run.sh script, to make it more clear to the user.

The kubectl provision cas command may fail due to local firewall settings. This can be fixed by opening port 8081/TCP on your local firewall. This may need to be written somewhere, maybe on the provision page. 
It is also explained in the tutorial that you need a Gitlab token, with read registry access. However, you also need one with write access, and this is not shown if you follow the link to "how to create a token". 